### PR TITLE
_animations.styl should be consistent with video 19

### DIFF
--- a/01 - Introduction - Start Here/css/_animations.styl
+++ b/01 - Introduction - Start Here/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/01 - Introduction - Start Here/css/_animations.styl
+++ b/01 - Introduction - Start Here/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/04 - Writing HTML with JSX/css/_animations.styl
+++ b/04 - Writing HTML with JSX/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/04 - Writing HTML with JSX/css/_animations.styl
+++ b/04 - Writing HTML with JSX/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/05 - Creating our application layout with components/css/_animations.styl
+++ b/05 - Creating our application layout with components/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/05 - Creating our application layout with components/css/_animations.styl
+++ b/05 - Creating our application layout with components/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/06 - Passing dyanmic data with Props/css/_animations.styl
+++ b/06 - Passing dyanmic data with Props/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/06 - Passing dyanmic data with Props/css/_animations.styl
+++ b/06 - Passing dyanmic data with Props/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/07 - React Router/css/_animations.styl
+++ b/07 - React Router/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/07 - React Router/css/_animations.styl
+++ b/07 - React Router/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/09 - The React Event System/css/_animations.styl
+++ b/09 - The React Event System/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/09 - The React Event System/css/_animations.styl
+++ b/09 - The React Event System/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/10 - State/css/_animations.styl
+++ b/10 - State/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/10 - State/css/_animations.styl
+++ b/10 - State/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/12 - Displaying State with JSX/css/_animations.styl
+++ b/12 - Displaying State with JSX/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/12 - Displaying State with JSX/css/_animations.styl
+++ b/12 - Displaying State with JSX/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/13 - Adding fish to an order/css/_animations.styl
+++ b/13 - Adding fish to an order/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/13 - Adding fish to an order/css/_animations.styl
+++ b/13 - Adding fish to an order/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/14 - Displaying our Order State with JSX/css/_animations.styl
+++ b/14 - Displaying our Order State with JSX/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/14 - Displaying our Order State with JSX/css/_animations.styl
+++ b/14 - Displaying our Order State with JSX/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/15 - Persisting State Data with Firebase/css/_animations.styl
+++ b/15 - Persisting State Data with Firebase/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/15 - Persisting State Data with Firebase/css/_animations.styl
+++ b/15 - Persisting State Data with Firebase/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/16 - Persisting State Data with localStorage/css/_animations.styl
+++ b/16 - Persisting State Data with localStorage/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/16 - Persisting State Data with localStorage/css/_animations.styl
+++ b/16 - Persisting State Data with localStorage/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/17 - Three Way Data Binding/css/_animations.styl
+++ b/17 - Three Way Data Binding/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/17 - Three Way Data Binding/css/_animations.styl
+++ b/17 - Three Way Data Binding/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/18 - Updating  + Removing State Items/css/_animations.styl
+++ b/18 - Updating  + Removing State Items/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/18 - Updating  + Removing State Items/css/_animations.styl
+++ b/18 - Updating  + Removing State Items/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/19 - React Animations/css/_animations.styl
+++ b/19 - React Animations/css/_animations.styl
@@ -7,7 +7,7 @@
 
 
 .order-enter
-  transition .5s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important

--- a/19 - React Animations/css/_animations.styl
+++ b/19 - React Animations/css/_animations.styl
@@ -35,10 +35,10 @@
     
 .count-leave
   transition all 0.25s
-  position absolute
   left 0
   bottom 0
   transform translateY(0)  // start it where it is
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)  // start it where it is
     

--- a/20 - Proptypes/css/_animations-finished.styl
+++ b/20 - Proptypes/css/_animations-finished.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/20 - Proptypes/css/_animations-finished.styl
+++ b/20 - Proptypes/css/_animations-finished.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/20 - Proptypes/css/_animations.styl
+++ b/20 - Proptypes/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/20 - Proptypes/css/_animations.styl
+++ b/20 - Proptypes/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/21 - ES6 Modules/css/_animations-finished.styl
+++ b/21 - ES6 Modules/css/_animations-finished.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/21 - ES6 Modules/css/_animations-finished.styl
+++ b/21 - ES6 Modules/css/_animations-finished.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)

--- a/21 - ES6 Modules/css/_animations.styl
+++ b/21 - ES6 Modules/css/_animations.styl
@@ -39,7 +39,7 @@
   left 0
   bottom 0
   transform translateY(0)
-  position absolute
+  position absolute !important
   &.count-leave-active
     transform translateY(-100%)
     

--- a/21 - ES6 Modules/css/_animations.styl
+++ b/21 - ES6 Modules/css/_animations.styl
@@ -6,7 +6,7 @@
 */
 
 .order-enter
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(-120%)
   max-height 0
   padding 0 !important
@@ -17,7 +17,7 @@
     transform translateX(0)
 
 .order-leave
-  transition all 0.3s
+  transition all 0.5s
   transform translateX(0)
   &.order-leave-active
     max-height 0
@@ -26,7 +26,7 @@
 
 
 .count-enter
-  transition all .2s
+  transition all 0.25s
   transform translateY(100%)
   &.count-enter-active
     opacity 1
@@ -35,7 +35,7 @@
     
   
 .count-leave
-  transition all .2s
+  transition all 0.25s
   left 0
   bottom 0
   transform translateY(0)


### PR DESCRIPTION
The animations transition times in video 19 for the slide in and count "cha-ching" are 500ms and 250ms respectively. This PR changes the styl files to be consistent with the video as well as the CSSTransitionGroup leave and enter timeouts.

I came across an issue with the css when following along to video 19. When animating the **count** I noticed my old count (the one leaving) was getting pushed to the side by the new one. Appending the `position absolute` with `!important` made the count animate properly.

Before `!important`
![count animation bug](https://cloud.githubusercontent.com/assets/3250463/12060267/cc8ec370-af20-11e5-85db-580dd820e72e.gif)

After `!important`
![count animation fix](https://cloud.githubusercontent.com/assets/3250463/12060271/dc35c832-af20-11e5-9971-fc44f64db6eb.gif)

**Note:** I was a little confused when I opened the **_animations.styl** to find that it had already been completed, while in the video you start form scratch. I assumed that you just decided to have it ready to go for the students as the course is focused on React and not CSS. Should the file actually be empty prior to the directory for video 20?