### PR TITLE
Fix Lint error in VSCode.

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -25,6 +25,6 @@
     "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
   },
   "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
+    "extends": "react-app"
   }
 }

--- a/stepped-solutions/Final Codebase/package.json
+++ b/stepped-solutions/Final Codebase/package.json
@@ -26,6 +26,6 @@
     "deploy": "ns ./build --cmd 'list ./content -s'"
   },
   "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
+    "extends": "react-app"
   }
 }


### PR DESCRIPTION
Updated eslintConfig to the recommended way in the create-react-app [documentation on Displaying Lint Output in the Editor](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#displaying-lint-output-in-the-editor).

This works well in VSCode, but have not tested in other editors.
