### PR TITLE
Hardcode react-router version

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -14,7 +14,7 @@
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-dom": "15.3.2",
-    "react-router": "^4.0.0-alpha.4"
+    "react-router": "4.0.0-alpha.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Similar to #24, `react-router@4.0.0-alpha.5` appears to have a bug that prevents React Router from executing cleanly.

```
Error in ./~/react-router/~/history/createBrowserHistory.js
Module not found: 'warning' in /oss/react-for-beginners/catch-of-the-day/node_modules/react-router/node_modules/history

@ ./~/react-router/~/history/createBrowserHistory.js 9:15-33

...
```

I encountered this issue while going through Episode 9 (Routing with React Router).