### PR TITLE
Updates path to eslintrc file

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -25,6 +25,6 @@
     "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
   },
   "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
+    "extends": "./node_modules/react-scripts/.eslintrc"
   }
 }


### PR DESCRIPTION
The previous path was non-existent (perhaps due to an update?). This fixes the path to point to the `.eslintrc` file in the react-scripts' node modules.

I was running into an issue where the editor couldn't find the file previously specified in the package.json. This fixed the issue.