### PR TITLE
Update watch script to make it work on Windows.

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "watch": "concurrently --names 'webpack, stylus' --prefix name 'npm run start' 'npm run styles:watch'",
+    "watch": "concurrently --names \"webpack, stylus\" --prefix name \"npm run start\" \"npm run styles:watch\"",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",


### PR DESCRIPTION
Hey Wes,

this pull request simply replaces the single quotes of the `watch` script with (escaped) double quotes in order to make `npm run watch` work on Windows.

I guess using double quotes there shouldn't be a problem with Linux, Mac OS etc.? Can you verify?

Cheers,
Thorsten