### PR TITLE
Fix for reference to linter in package.json and adding packages so that linter works as expected in editor

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -25,6 +25,6 @@
     "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
   },
   "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
+    "extends": "./node_modules/react-scripts/.eslintrc"
   }
 }

--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -4,7 +4,12 @@
   "private": true,
   "devDependencies": {
     "autoprefixer-stylus": "0.10.0",
+    "babel-eslint": "^7.1.1",
     "concurrently": "3.0.0",
+    "eslint": "^3.12.2",
+    "eslint-plugin-flowtype": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-react": "^6.8.0",
     "react-scripts": "0.6.1",
     "stylus": "0.54.5"
   },


### PR DESCRIPTION
Problem: Atom uses reference in package.json to eslintConfig which is incorrect because package maintainer has restructured files and directories in `./node_modules/react-scripts/`.

Once fixed Atom reports a series of missing packages. Once adding those, those added in the second commit, linter works as expected and problem is fixed.