### PR TITLE
Fix security rules to prevent possible workaround

### DIFF
--- a/catch-of-the-day/security-rules.json
+++ b/catch-of-the-day/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/04/src/security-rules.json
+++ b/stepped-solutions/04/src/security-rules.json
@@ -1,4 +1,4 @@
-// These are your firebase security rules - put then in the "Security & Rules" tab of your 
+// These are your firebase security rules - put them in the "Security & Rules" tab of your database
 {
     "rules": {
         // won't let people delete an existing room
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/06/src/security-rules.json
+++ b/stepped-solutions/06/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/09/src/security-rules.json
+++ b/stepped-solutions/09/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/11/src/security-rules.json
+++ b/stepped-solutions/11/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/12/src/security-rules.json
+++ b/stepped-solutions/12/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/13/src/security-rules.json
+++ b/stepped-solutions/13/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/14/src/security-rules.json
+++ b/stepped-solutions/14/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/16/src/security-rules.json
+++ b/stepped-solutions/16/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/19/src/security-rules.json
+++ b/stepped-solutions/19/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/20/src/security-rules.json
+++ b/stepped-solutions/20/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/21/src/security-rules.json
+++ b/stepped-solutions/21/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/22/src/security-rules.json
+++ b/stepped-solutions/22/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/24/src/security-rules.json
+++ b/stepped-solutions/24/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/25/src/security-rules.json
+++ b/stepped-solutions/25/src/security-rules.json
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }

--- a/stepped-solutions/Final Codebase/src/security-rules.json
+++ b/stepped-solutions/Final Codebase/src/security-rules.json
@@ -1,4 +1,4 @@
-// These are your firebase security rules - put then in the "Security & Rules" tab of your 
+// These are your firebase security rules - put them in the "Security & Rules" tab of your database
 {
     "rules": {
         // won't let people delete an existing room
@@ -6,7 +6,7 @@
         ".read": true,
         "$room" : {
           // only the store owner can edit the data
-          ".write" : "newData.child('owner').val() === auth.uid",
+          ".write" : "auth != null && (!data.exists() || data.child('owner').val() === auth.uid)",
           ".read" : true
         }
     }


### PR DESCRIPTION
The previous security rules use `newData` to check the current `uid` against the owner of a store, but since `newData` represents the data as it would exist after the attempted operation, this will allow anyone to write data to that store as long as they include their own `uid` as `owner`. Even an unauthenticated user can write to a store ref if they include `owner = null`.

`auth != null`
Prevents an unauthenticated user from writing data to a new store.

`(!data.exists() || data.child('owner').val() === auth.uid)`
Allows any user to write data to a new store, but prevents a user other than the owner from writing to an existing store. `data` is used rather than `newData` to check against the existing `owner` rather than one that could be provided in the write operation.