### PR TITLE
Fix export of sample fishes

### DIFF
--- a/catch-of-the-day/src/sample-fishes.js
+++ b/catch-of-the-day/src/sample-fishes.js
@@ -1,5 +1,5 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
     image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
@@ -72,3 +72,5 @@ module.exports = {
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/04/src/sample-fishes.js
+++ b/stepped-solutions/04/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/06/src/sample-fishes.js
+++ b/stepped-solutions/06/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/09/src/sample-fishes.js
+++ b/stepped-solutions/09/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/11/src/sample-fishes.js
+++ b/stepped-solutions/11/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/12/src/sample-fishes.js
+++ b/stepped-solutions/12/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/13/src/sample-fishes.js
+++ b/stepped-solutions/13/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/14/src/sample-fishes.js
+++ b/stepped-solutions/14/src/sample-fishes.js
@@ -1,8 +1,8 @@
 // This is just some sample data so you don't have to think of your own!
-module.exports = {
+const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ module.exports = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ module.exports = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ module.exports = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ module.exports = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ module.exports = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ module.exports = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ module.exports = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,9 +66,11 @@ module.exports = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'
   }
 };
+
+export default fishes;

--- a/stepped-solutions/16/src/sample-fishes.js
+++ b/stepped-solutions/16/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/19/src/sample-fishes.js
+++ b/stepped-solutions/19/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/20/src/sample-fishes.js
+++ b/stepped-solutions/20/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/21/src/sample-fishes.js
+++ b/stepped-solutions/21/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/22/src/sample-fishes.js
+++ b/stepped-solutions/22/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/24/src/sample-fishes.js
+++ b/stepped-solutions/24/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/25/src/sample-fishes.js
+++ b/stepped-solutions/25/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'

--- a/stepped-solutions/Final Codebase/src/sample-fishes.js
+++ b/stepped-solutions/Final Codebase/src/sample-fishes.js
@@ -2,7 +2,7 @@
 const fishes = {
   fish1: {
     name: 'Pacific Halibut',
-    image: 'http://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/36248396/5/stock-photo-36248396-blackened-cajun-sea-bass.jpg',
     desc: 'Everyones favorite white fish. We will cut it to the size you need and ship it.',
     price: 1724,
     status: 'available'
@@ -10,7 +10,7 @@ const fishes = {
 
   fish2: {
     name: 'Lobster',
-    image: 'http://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/32135274/5/stock-photo-32135274-cooked-lobster.jpg',
     desc: 'These tender, mouth-watering beauties are a fantastic hit at any dinner party.',
     price: 3200,
     status: 'available'
@@ -18,7 +18,7 @@ const fishes = {
 
   fish3: {
     name: 'Sea Scallops',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58624176/5/stock-photo-58624176-scallops-on-black-stone-plate.jpg',
     desc: 'Big, sweet and tender. True dry-pack scallops from the icey waters of Alaska. About 8-10 per pound',
     price: 1684,
     status: 'unavailable'
@@ -26,7 +26,7 @@ const fishes = {
 
   fish4: {
     name: 'Mahi Mahi',
-    image: 'http://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/12556651/5/stock-photo-12556651-mahimahi.jpg',
     desc: 'Lean flesh with a mild, sweet flavor profile, moderately firm texture and large, moist flakes. ',
     price: 1129,
     status: 'available'
@@ -34,7 +34,7 @@ const fishes = {
 
   fish5: {
     name: 'King Crab',
-    image: 'http://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/18294110/5/stock-photo-18294110-king-crab-legs.jpg',
     desc: 'Crack these open and enjoy them plain or with one of our cocktail sauces',
     price: 4234,
     status: 'available'
@@ -42,7 +42,7 @@ const fishes = {
 
   fish6: {
     name: 'Atlantic Salmon',
-    image: 'http://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/56241842/5/stock-photo-56241842-salmon-fish.jpg',
     desc: 'This flaky, oily salmon is truly the king of the sea. Bake it, grill it, broil it...as good as it gets!',
     price: 1453,
     status: 'available'
@@ -50,7 +50,7 @@ const fishes = {
 
   fish7: {
     name: 'Oysters',
-    image: 'http://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/58626682/5/stock-photo-58626682-fresh-oysters-on-a-black-stone-plate-top-view.jpg',
     desc: 'A soft plump oyster with a sweet salty flavor and a clean finish.',
     price: 2543,
     status: 'available'
@@ -58,7 +58,7 @@ const fishes = {
 
   fish8: {
     name: 'Mussels',
-    image: 'http://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/40450406/5/stock-photo-40450406-steamed-mussels.jpg',
     desc: 'The best mussels from the Pacific Northwest with a full-flavored and complex taste.',
     price: 425,
     status: 'available'
@@ -66,7 +66,7 @@ const fishes = {
 
   fish9: {
     name: 'Jumbo Prawns',
-    image: 'http://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
+    image: 'https://i.istockimg.com/file_thumbview_approve/67121439/5/stock-photo-67121439-fresh-tiger-shrimp-on-ice-on-a-black-stone-table.jpg',
     desc: 'With 21-25 two bite prawns in each pound, these sweet morsels are perfect for shish-kabobs.',
     price: 2250,
     status: 'available'


### PR DESCRIPTION
I'm in the middle of the course and found a problem in lesson 14 were the sample data gets loaded into the state.

I looked into the stepped solutions and from folder 14 to 15 there was a code change in `sample-fishes.js` from
```js
module.exports = {
// sample data
};
```
to
```js
const fishes = {
// sample data
};

export default fishes;
```

I hope the latter one is the correct way, otherwise I don't know how to import the sample date in `App.js`.

PS: Also the image URLs in the stepped solutions are now https too (see pull request #56).