### PR TITLE
updated firebase to 4.10.1

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "autoprefixer-stylus": "0.14.0",
-    "firebase": "^4.10.0",
+    "firebase": "^4.10.1",
     "prop-types": "^15.6.0",
     "re-base": "3.2.2",
     "react": "^16.3.0-alpha.1",
@@ -20,13 +20,10 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "watch":
-      "concurrently --names \"webpack, stylus\" --prefix name \"npm run start\" \"npm run styles:watch\"",
+    "watch": "concurrently --names \"webpack, stylus\" --prefix name \"npm run start\" \"npm run styles:watch\"",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "styles":
-      "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
-    "styles:watch":
-      "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
+    "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
+    "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
   }
 }


### PR DESCRIPTION
Hey Wes!
Firebase Team finally fixed the issue with incorrect parsing dataURL causing warnings in browser's console like 

> ⚠ FIREBASE WARNING: Invalid query string segment:"

P.S. I've just updated firebase but npm has broken your beautiful formatting in the "scripts" section.