### PR TITLE
Add parseFloat to handleChange in EditFish

### DIFF
--- a/stepped-solutions/Finished App/src/components/EditFishForm.js
+++ b/stepped-solutions/Finished App/src/components/EditFishForm.js
@@ -19,7 +19,10 @@ class EditFishForm extends React.Component {
     // 1. Take a copy of the curernt fish
     const updatedFish = {
       ...this.props.fish,
-      [event.currentTarget.name]: event.currentTarget.value
+      [event.currentTarget.name]:
+        event.currentTarget.name === 'price'
+          ? parseFloat(event.currentTarget.value)
+          : event.currentTarget.value
     };
     this.props.updateFish(this.props.index, updatedFish);
   };


### PR DESCRIPTION
Hi Wes,
I discovered when adding prop type that when the price is changed in the EditFishForm it is also changed back into a string, as it is not parsed to a float, and fails prop type validation.

I've refactored the handleChange method to parseFloat() on the price key currentTarget value. 