### PR TITLE
Replace componentDidMount with componentWillMount to avoid an extra rendering

### DIFF
--- a/stepped-solutions/Finished App/src/components/App.js
+++ b/stepped-solutions/Finished App/src/components/App.js
@@ -17,7 +17,7 @@ class App extends React.Component {
     match: PropTypes.object
   };
 
-  componentDidMount() {
+  componentWillMount() {
     const { params } = this.props.match;
     // first reinstate our localStorage
     const localStorageRef = localStorage.getItem(params.storeId);


### PR DESCRIPTION
According to React docs 
``` 
Calling setState() in this method will trigger an extra rendering, but it will happen before the browser updates the screen. 
This guarantees that even though the render() will be called twice in this case, the user won’t see the intermediate state. 
Use this pattern with caution because it often causes performance issues. It can, however, be necessary for cases like modals and tooltips when you need to measure a DOM node before rendering something that depends on its size or position.
```
So to avoid that we should use `componentWillMount` instead of `componentDidMount`