### PR TITLE
Remove Node version warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 .idea
 notes.md
+React-for-Beginners


### PR DESCRIPTION
Since the node version problem was resolved with the change in deps in the commit a33a29377da153cd33c17721fd452337569f4e1
Hence, removed the warning from the readme. 

I was stuck on the same for about a day or so. Following through the course, I saw the first video and read the `README`. In effect, I downgraded my node to v9.11.1 was stuck for quite a while, as the dependencies shown in the first video were quite different to what I cloned. Also, every time I ran `npm install` and `npm start`. My localhost showed a 404 page, while yours was running. 