### PR TITLE
Update styles:watch command to use -- to prevent duplication

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -25,7 +25,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
-    "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
+    "styles:watch": "npm run styles -- -w"
   },
   "browserslist": [
     ">0.2%",

--- a/stepped-solutions/Finished App/package.json
+++ b/stepped-solutions/Finished App/package.json
@@ -25,7 +25,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
-    "styles:watch": "stylus -u autoprefixer-stylus -w ./src/css/style.styl -o ./src/css/style.css"
+    "styles:watch": "npm run styles -- -w"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
The `styles:watch` command can be simplified by using `--` at the end of the `npm run` command and then adding whatever arguments need to be appended to the original command.