### PR TITLE
Removing incompatible  browerslist flag

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -29,7 +29,6 @@
   },
   "browserslist": [
     ">0.2%",
-    "not dead",
     "not ie <= 11",
     "not op_mini all"
   ]


### PR DESCRIPTION
When running `npm run styles:watch` I received the error `BrowserslistError: Unknown browser query 'dead'`

According to [the browerslist github](https://github.com/browserslist/browserslist/issues/266) the solution is to disable minimization in webpack or upgrade to cssnano 4. However since we're using `create-react-app` (and have not ejected) those aren't viable options.

Therefore, simply removing this line fixes the problem (and I guess, supports dead browsers, but that shouldn't be a concern for a tutorial, right?)

Thanks for all your hard work @wesbos ! 