### PR TITLE
Add sans-serif fallback to button and input styles

### DIFF
--- a/catch-of-the-day/src/css/style.styl
+++ b/catch-of-the-day/src/css/style.styl
@@ -218,7 +218,7 @@ button, input[type=submit]
   border 1px solid black
   font-weight 600
   font-size 1.5rem
-  font-family 'Open Sans'
+  font-family 'Open Sans', sans-serif
   transition all 0.2s
   position relative
   z-index 2


### PR DESCRIPTION
Don't have open sans on this computer and noticed sans-serif wasn't a fallback option on buttons and submit inputs. Thought this would fix it real quick, as the browser default serif option didn't look quite right. Thanks for a great course!