### PR TITLE
Update package.json

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "dev": "react-scripts start",
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "watch": "concurrently --names \"webpack, stylus\" --prefix name \"npm run start\" \"npm run styles:watch\"",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "eject": "react-scripts eject",
     "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
     "now-build": "npm run build && mv build dist",


### PR DESCRIPTION
On npm start I was getting the following error: opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ], library: 'digital envelope routines', reason: 'unsupported', code: 'ERR_OSSL_EVP_UNSUPPORTED'

https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os

I did the quick fix listed on stack overflow which was running this line of code in the project terminal. 

export NODE_OPTIONS=--openssl-legacy-provider

After running that and doing an npm start the project started working again.