### PR TITLE
Project does not start or auto-reload

### DIFF
--- a/catch-of-the-day/package.json
+++ b/catch-of-the-day/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "dev": "react-scripts start",
-    "start": "react-scripts start",
+    "start": "export SET NODE_OPTIONS=--openssl-legacy-provider && FAST_REFRESH=false react-scripts start",
     "watch": "concurrently --names \"webpack, stylus\" --prefix name \"npm run start\" \"npm run styles:watch\"",
-    "build": "react-scripts build",
+    "build": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
     "eject": "react-scripts eject",
     "styles": "stylus -u autoprefixer-stylus ./src/css/style.styl -o ./src/css/style.css",
     "now-build": "npm run build && mv build dist",


### PR DESCRIPTION
I am starting on this course on 3/25. I git cloned the repo and started the course. Performing the npm start command gave me the following error "error:0308010C:digital envelope routines::unsupported". This led me to the following Stack Overflow URL - https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os

I implemented the recommended solution and that fixed the npm start command. I then noticed that on save my browser was not auto-reloading which led me to the next stack overflow URL - https://stackoverflow.com/questions/43274925/development-server-of-create-react-app-does-not-auto-refresh. 

This PR adds both legacy support (webpack) and auto-reload when doing an npm start.